### PR TITLE
Add ansible python interpreter

### DIFF
--- a/episodes/117/etcd-lab/ansible/playbook.yaml
+++ b/episodes/117/etcd-lab/ansible/playbook.yaml
@@ -1,15 +1,21 @@
 ---
 - name: common
   hosts: all
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
   roles:
     - common
 
 - name: haproxy
   hosts: lb
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
   roles:
     - haproxy
 
 - name: etcd
   hosts: etcd
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
   roles:
     - etcd


### PR DESCRIPTION
Adding python interpreter otherwise ansible fails with the following message since `python` binary or 
 is not available in ubuntu 18.04 by default.
```
TASK [Gathering Facts] ******************************************************************
fatal: [etcd-lb0]: FAILED! => {"changed": false, "module_stderr": "/bin/sh: 1: /usr/bin/python: not found\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 127}
fatal: [etcd-member2]: FAILED! => {"changed": false, "module_stderr": "/bin/sh: 1: /usr/bin/python: not found\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 127}
fatal: [etcd-member1]: FAILED! => {"changed": false, "module_stderr": "/bin/sh: 1: /usr/bin/python: not found\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 127}
fatal: [etcd-member0]: FAILED! => {"changed": false, "module_stderr": "/bin/sh: 1: /usr/bin/python: not found\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 127}
```

cc @mauilion 