### PR TITLE
Add explicit permissions to cert copy

### DIFF
--- a/episodes/117/etcd-lab/ansible/roles/etcd/tasks/main.yml
+++ b/episodes/117/etcd-lab/ansible/roles/etcd/tasks/main.yml
@@ -36,7 +36,9 @@
     src: /etc/etcd/pki/{{item}}
     dest: /shared/{{item}}
     remote_src: yes
-    mode: preserve
+    owner: root
+    group: root
+    mode: '0755'
   with_items:
     - ca.crt
     - ca.key


### PR DESCRIPTION
`mode: preserve` doesn't work with `remote_src: yes` directive. 

ref: https://github.com/ansible/ansible/issues/39279#issuecomment-384478619

cc @mauilion 